### PR TITLE
show event body in the Calendar view.

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -8,6 +8,7 @@
   {% for child in this.pagination.items|sort(attribute='date', reverse=true) %}
           <h2>{{ child.title }}</h2>
           <p>{{ child.date.strftime("%Y-%m-%d %H:%M") }}</p>
+          <p>{{ child.body }}</p>
           {% if child.url %}
           <a href="{{ child.url }}">Link zum Event (extern)</a>
           {% else %}


### PR DESCRIPTION
  - the event list under 'Kalender/<YEAR>' lists the
    events only with the title, date and an event link.

  - this commit adds the event text / description
    in this list

---- 
Spricht was dagegen den Text mit in die Liste aufzunehmen?

----
**Aktuell:**
![current](https://user-images.githubusercontent.com/3081095/50769407-278c4d00-1284-11e9-8bdc-d99cb80b077c.png)

----
**PR**
![with-body](https://user-images.githubusercontent.com/3081095/50769441-3e32a400-1284-11e9-98dd-ae245b98809c.png)

