### PR TITLE
Link zu "Maker vs Virus" entfernt, Anleitung aus dem wiki teilweise integriert

### DIFF
--- a/content/corona/contents.lr
+++ b/content/corona/contents.lr
@@ -40,12 +40,16 @@ Wir geben diese Schilde und Helferlein gerne kostenlos ab, aber freuen uns über
 Nein! Wir sind keine Fachmänner für klinische Austattung, übernehmen also keine Haftung. Diese Helfer werden auf eigene Gefahr eingesetzt, dennoch sind wir davon überzeugt das Richtige zu tun.
 Wenn die Alternative ist sich eine aufgeschnittene PET-Flasche um den Kopf zu binden oder gar nichts zu nutzen, sind wir davon überzeugt mit unseren Produkten einen sinnvollen Beitrag leisten zu können.
 
-# Kann ich mithelfen?
-Wir sind organisiert und als Hub auf [Maker vs Virus](https://makervsvirus.org/) registriert.  
-Direkt zu uns kommt ihr via [unserer Anleitung](https://wiki.section77.de/themen/drucken_gegen_corona_faq)
+# Wie kann ich mithelfen?
 
-# Wie können wir helfen?
-* Fertigen von Bauteilen für Einrichtungen in der Region (PLZ-Bereich 77xxx)
-* Vermitteln von Kontakten zu Makern in anderen Regionen über https://makervsvirus.org/
+Wir fertigen Bauteile für Einrichtungen in der Region (PLZ-Bereich 77xxx) und vermitteln ggf. Kontakte zu Makern in anderen Regionen.
+
+* Bitte [hier einen Benutzer anlegen](https://chat.section77.de/signup_user_complete/?id=4w5wq9jr7ig4uypfi65bizaotc)
+* Anschließend im Kanal [Antivirus-Vorstellung](https://chat.section77.de/section77/channels/av-vorstellung) kurz vorstellen: Wo wohnst Du, was für einen Drucker hast Du
+
+Falls Du irgendwo hängen bleibst: schreib 'ne Mail an [antivirus@section77.de](mailto:antivirus@section77.de), dann helfen wir Dir weiter.
+
+Wir freuen uns auf dich!
+
 ----
 class: default


### PR DESCRIPTION
Nach einem Gespräch mit W. finde ich man sollte die Einstiegsschwelle senken um in den Mattermost chat zu kommen. Viele wollen und können die wiki Seite nicht modifizieren.

Daher mein Vorschlag: Lass uns die Leute die helfen wollen nach av-vorstellung führen, sie dort begrüßen, einer der Stammuser kann sie ins wiki eintragen und dann gehts weiter