### PR TITLE
freie Plätze bei OBS-Workshop

### DIFF
--- a/content/kalender/2023/2023-06-17/contents.lr
+++ b/content/kalender/2023/2023-06-17/contents.lr
@@ -12,9 +12,9 @@ url: https://www.openbikesensor.org/
 ---
 body:
 #### text-block ####
- text: Mach mit und bau dir einen Überholabstandsmesser für dein Rad. Wir unterstützen Dich dabei. Bausätze werden so vorbereitet, dass es "einfach" ist, einen OBS für sich selbst zusammenzubauen. Teilnahmegebühr 10 Euro, das gebaute Gerär kann danach mitgenommen werden.
+ text: Mach mit und bau dir einen Überholabstandsmesser für dein Rad. Wir unterstützen Dich dabei. Bausätze werden so vorbereitet, dass es "einfach" ist, einen OBS für sich selbst zusammenzubauen. Teilnahmegebühr 10 Euro, das gebaute Gerät kann danach mitgenommen werden.
 
-Es gibt noch zwei freie Plätze für Freitag. Anmelden bei monika.kunschner at adfc-bw.de
+Es gibt noch zwei freie Plätze für Samstag. Anmelden bei monika.kunschner at adfc-bw.de
 
 ---
 class: default

--- a/content/kalender/2023/2023-06-17/contents.lr
+++ b/content/kalender/2023/2023-06-17/contents.lr
@@ -8,13 +8,13 @@ end: 2023-06-17 17:00
 ---
 type: Event
 ---
-url: https://offenburg.adfc.de/neuigkeit/workshops-openbikesensor
+url: https://www.openbikesensor.org/
 ---
 body:
 #### text-block ####
- text: Mach mit und bau dir einen Überholabstandsmesser für dein Rad. Wir unterstützen Dich dabei. Bausätze werden so vorbereitet, dass es "einfach" ist, einen OBS für sich selbst zusammenzubauen.
+ text: Mach mit und bau dir einen Überholabstandsmesser für dein Rad. Wir unterstützen Dich dabei. Bausätze werden so vorbereitet, dass es "einfach" ist, einen OBS für sich selbst zusammenzubauen. Teilnahmegebühr 10 Euro, das gebaute Gerär kann danach mitgenommen werden.
 
-Der Workshop ist leider ausgebucht :/
+Es gibt noch zwei freie Plätze für Freitag. Anmelden bei monika.kunschner at adfc-bw.de
 
 ---
 class: default


### PR DESCRIPTION
Es gibt aktuell noch freie Plätze, außerdem gibt es die Seite mit der Anmeldung beim ADFC nicht mehr.