### PR TITLE
Only run the job if the repository is section77/website

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   gh-pages:
+    # Only run the job if the repository is section77/website
+    if: github.repository == 'section77/website'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Only run the job if the repository is "section77/website", because it fails on all forks and causes error mails there.