### PR TITLE
Vereinfachtes Impressum

### DIFF
--- a/content/impressum/contents.lr
+++ b/content/impressum/contents.lr
@@ -7,7 +7,7 @@ body:
 #### text-block ####
 text:
 
-## Angaben gemäß § 5 DDG:
+## Verantwortlich für den Inhalt der Seiten:
 
 Section77 e.V.  
 Wiesenstraße 11  
@@ -33,24 +33,5 @@ Aus Gründen haben wir die Zahlen oben falsch dargestellt, bitte ersetzen Sie di
 Eintragung im Vereinsregister.  
 Registergericht: Freiburg  
 Registernummer: 700866  
-
-## Quellenangaben für die verwendeten Bilder und Grafiken:
-
-Chaos Computer Club 
-www.ccc.de  
-
-## Haftungsausschluss
-
-### Haftung für Inhalte
-
-Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen. Als Diensteanbieter sind wir gemäß § 7 Abs.1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.
-
-### Haftung für Links
-
-Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.
-
-### Urheberrecht
-
-Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
 ----
 class: default


### PR DESCRIPTION
Nach den zuletzt notwendigen Änderungen habe ich mich nochmal eingelesen und unser Impressum vereinfacht, so dass bei künftigen Umbenennungen oder sonstigen redaktionellen Änderungen kein Aufwand entsteht:
- Referenz auf § 5 DDG entfernt: Es gibt keine rechtliche Pflicht, den Paragraphen oder das Gesetz zu nennen.
- Disclaimer entfernt: Der Nutzen dieser generischen Disclaimer ist umstritten. Bei eventuellen Verstößen hilft es rechtlich nicht.
- Quellenangabe auf CCC entfernt: Soweit mir bekannt ist verwenden wir keine Bilder oder Grafiken vom Bundes-CCC, sondern nur unser eigenes Logo und eigene Fotos.