### PR TITLE
Add .direnv to nixignore for local build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 /.keys/
 /.vscode/
+.direnv/


### PR DESCRIPTION
Add local .direnv for local building the website to .gitignore to not unintentionally push a cache to the repo
